### PR TITLE
Normalize country names in bed data to match the other sources

### DIFF
--- a/data/process_bed_data.py
+++ b/data/process_bed_data.py
@@ -21,6 +21,17 @@ def preprocess_bed_data(path=_BED_DATA_PATH):
     df.set_index("Country/Region", inplace=True)
     df["Latest Bed Estimate"] = df.apply(_get_latest_bed_estimate, axis=1)
 
+    # Rename countries to match demographics and disease data
+    df = df.rename(index={
+        "Iran, Islamic Rep.": "Iran",
+        "Korea, Rep.": "Korea, South",
+        "Russian Federation": "Russia",
+        "Egypt, Arab Rep.": "Egypt",
+        "Slovak Republic": "Slovakia",
+        "Congo, Dem. Rep.": "Congo (Kinshasa)",
+        # "Brunei Darussalam": "Brunei",
+    })
+
     return df
 
 


### PR DESCRIPTION
Shell output of mismatch between country names of the 3 data sources:

```
In [8]: bed = set(BED_DATA.index)

In [9]: len(bed)
Out[9]: 264

In [10]: DISEASE_DATA = pd.read_csv("data/latest_disease_data.csv")

In [11]: DISEASE_DATA = DISEASE_DATA.set_index("Country/Region")

In [12]: dis = set(DISEASE_DATA.index)

In [13]: demo = set(DEMOGRAPHIC_DATA.index)

In [14]: len(dis)
Out[14]: 135

In [15]: len(demo)
Out[15]: 125

In [16]: main - demo
Out[16]: {'United States'}

In [17]: demo - main
Out[17]:
{'Brunei',
 'Congo (Kinshasa)',
 'Cruise Ship',
 'Czechia',
 'Egypt',
 'French Guiana',
 'Guadeloupe',
 'Holy See',
 'Iran',
 'Korea, South',
 'Martinique',
 'Reunion',
 'Russia',
 'Slovakia',
 'Taiwan*',
 'US'}

In [18]: dis - demo
Out[18]:
{'Curacao',
 'Eswatini',
 'Gabon',
 'Ghana',
 'Guatemala',
 'Guernsey',
 'Jersey',
 'Mauritania',
 'Namibia',
 'Rwanda',
 'Saint Lucia',
 'Saint Vincent and the Grenadines',
 'Seychelles',
 'Suriname',
 'Trinidad and Tobago',
 'Uruguay',
 'Venezuela',
 'occupied Palestinian territory'}


In [20]: demo - main
Out[20]:
{'Brunei',
 'Congo (Kinshasa)',
 'Cruise Ship',
 'Czechia',
 'Egypt',
 'French Guiana',
 'Guadeloupe',
 'Holy See',
 'Iran',
 'Korea, South',
 'Martinique',
 'Reunion',
 'Russia',
 'Slovakia',
 'Taiwan*',
 'US'}

In [21]: demo - dis
Out[21]:
{'Brunei',
 'Cruise Ship',
 'French Guiana',
 'Guadeloupe',
 'Holy See',
 'Martinique',
 'North Macedonia',
 'Reunion'}
 

 In [22]: dis - demo
Out[22]:
{'Curacao',
 'Eswatini',
 'Gabon',
 'Ghana',
 'Guatemala',
 'Guernsey',
 'Jersey',
 'Mauritania',
 'Namibia',
 'Rwanda',
 'Saint Lucia',
 'Saint Vincent and the Grenadines',
 'Seychelles',
 'Suriname',
 'Trinidad and Tobago',
 'Uruguay',
 'Venezuela',
 'occupied Palestinian territory'}

```