### PR TITLE
Inject CSS for min graph widths and menu hiding

### DIFF
--- a/corona-calculator.py
+++ b/corona-calculator.py
@@ -6,6 +6,7 @@ import graphing
 import models
 from data import constants
 from interface.elements import reported_vs_true_cases
+from interface import css
 from utils import COLOR_MAP, generate_html, graph_warning
 
 # estimates from https://github.com/midas-network/COVID-19/tree/master/parameter_estimates/2019_novel_coronavirus
@@ -93,6 +94,10 @@ def _fetch_country_data():
 
 
 def run_app():
+
+    css.hide_menu()
+    css.limit_plot_size()
+
     # Get cached country data
     countries = _fetch_country_data()
 

--- a/graphing.py
+++ b/graphing.py
@@ -19,6 +19,7 @@ def plot_true_versus_confirmed(confirmed, predicted):
 
 
 def infection_graph(df, y_max):
+    # We cannot explicitly set graph width here, have to do it as injected css: see interface.css
     fig = px.line(df, x="Days", y="Forecast", color="Status", template=TEMPLATE)
     fig.update_yaxes(range=[0, y_max])
     return fig

--- a/graphing.py
+++ b/graphing.py
@@ -3,6 +3,9 @@ import plotly.express as px
 
 TEMPLATE = "plotly_white"
 
+def _set_legends(fig):
+    fig.layout.update(legend=dict(x=-.1, y=1.2))
+    fig.layout.update(legend_orientation="h")
 
 def plot_true_versus_confirmed(confirmed, predicted):
     df = pd.DataFrame(
@@ -22,6 +25,7 @@ def infection_graph(df, y_max):
     # We cannot explicitly set graph width here, have to do it as injected css: see interface.css
     fig = px.line(df, x="Days", y="Forecast", color="Status", template=TEMPLATE)
     fig.update_yaxes(range=[0, y_max])
+    _set_legends(fig)
     return fig
 
 
@@ -45,8 +49,9 @@ def hospitalization_graph(df, number_of_beds, y_max):
         name="Number of Beds",
         fill="tozeroy",
         opacity=0.1,
-        fillcolor="rgba(255,0,0,.1)",
-        line={"color": "rgba(255,0,0,.5)"},
+        fillcolor="rgba(50,255,140,.2)",
+        line={"color": "rgba(50,255,140,.5)"},
     )
     fig.update_yaxes(range=[0, y_max])
+    _set_legends(fig)
     return fig

--- a/interface/css.py
+++ b/interface/css.py
@@ -27,7 +27,7 @@ def limit_plot_size(limit='95vw'):
 
     plot_style = """
             <style>
-         @media screen and (max-width:7000px)  {
+         @media screen and (max-width:700px)  {
          .js-plotly-plot, .plotly, .plot-container 
         {min-width:""" + limit + """;
         max-width:300px;}

--- a/interface/css.py
+++ b/interface/css.py
@@ -1,0 +1,38 @@
+import streamlit as st
+
+
+# This module uses markdown with unsafe HTML injection to inject styles we want
+# See https://discuss.streamlit.io/t/are-you-using-html-in-markdown-tell-us-why/96/53
+
+def _inject(css):
+    st.markdown(css, unsafe_allow_html=True)
+
+
+def hide_menu():
+    hide_menu_style = """
+        <style>
+
+        #MainMenu {visibility: hidden;}
+        
+    </style>
+        """
+    _inject(hide_menu_style)
+
+
+def limit_plot_size(limit='95vw'):
+    """
+    In browsers that are smaller than 700px (the streamlit column size),
+    set the min width of graphs `limit`.
+    """
+
+    plot_style = """
+            <style>
+         @media screen and (max-width:7000px)  {
+         .js-plotly-plot, .plotly, .plot-container 
+        {min-width:""" + limit + """;
+        max-width:300px;}
+        }
+        </style>
+        """
+
+    _inject(plot_style)


### PR DESCRIPTION
Fixes https://github.com/archydeberker/corona-calculator/issues/33.

This is a combination of hacks from https://community.plot.ly/t/plot-sizing-problems/1620/24 and https://discuss.streamlit.io/t/are-you-using-html-in-markdown-tell-us-why/96/44.

It uses a media query to set the minimum graph width to `95vw` if the screen width is less than `700 px` (the Streamlit column width).

It also hides the hamburger menu in the top right.