### PR TITLE
Feature: add controls for behaviour of asymptomatic individuals

### DIFF
--- a/corona-calculator.py
+++ b/corona-calculator.py
@@ -107,7 +107,8 @@ class Sidebar:
 
         st.sidebar.markdown(
             body=generate_html(
-                text=f"We're using an estimated transmission probability of {transmission_probability * 100:.1f}%,"
+                text=f"We're using an estimated transmission probability of {transmission_probability * 100:.1f}%. "
+                f"This probability is diminished by 45% for asymptomatic cases, "
                 f" see our <a href='https://www.notion.so/coronahack/Modelling-d650e1351bf34ceeb97c82bd24ae04cc'> methods for details</a>.",
                 line_height=0,
                 font_size="10px",

--- a/corona-calculator.py
+++ b/corona-calculator.py
@@ -207,9 +207,6 @@ def run_app():
     true_cases_estimator = models.TrueInfectedCasesModel(
         constants.ReportingRate.default
     )
-    diagnosed_cases_estimator = models.DiagnosedCasesModel(
-        constants.ReportingRate.default
-    )
     asymptomatic_cases_estimator = models.AsymptomaticCasesModel(
         constants.AsymptomaticRate.default
     )
@@ -219,7 +216,6 @@ def run_app():
     sir_model_2 = models.SIRModel2(
         transmission_rate_per_contact=constants.TransmissionRatePerContact.default_per_symptom_state,
         contact_rate=contact_rate,
-        diagnosed_cases_model=diagnosed_cases_estimator,
         asymptomatic_cases_model=asymptomatic_cases_estimator,
         recovery_rate=constants.RecoveryRate.default,
         normal_death_rate=constants.MortalityRate.default,

--- a/corona-calculator.py
+++ b/corona-calculator.py
@@ -90,9 +90,9 @@ class Sidebar:
         )
 
         slider_person_descriptions = {
-            constants.InfectionState.ASYMPTOMATIC_UNDIAGNOSED : "an individual with no symptoms",
-            constants.InfectionState.SYMPTOMATIC_UNDIAGNOSED : "an individual with unconfirmed symptoms",
-            constants.InfectionState.DIAGNOSED : "an individual diagnosed with COVID-19"
+            constants.SymptomState.ASYMPTOMATIC_UNDIAGNOSED : "an individual with no symptoms",
+            constants.SymptomState.SYMPTOMATIC_UNDIAGNOSED : "an individual with unconfirmed symptoms",
+            constants.SymptomState.DIAGNOSED : "an individual diagnosed with COVID-19"
         }
 
         self.contact_rate = {
@@ -193,7 +193,7 @@ def run_app():
     contact_rate = sidebar.contact_rate
 
     sir_model_2 = models.SIRModel2(
-        transmission_rate_per_contact=constants.TransmissionRatePerContact.default_per_infection_state,
+        transmission_rate_per_contact=constants.TransmissionRatePerContact.default_per_symptom_state,
         contact_rate=contact_rate,
         diagnosed_cases_model=diagnosed_cases_estimator,
         asymptomatic_cases_model=asymptomatic_cases_estimator,

--- a/corona-calculator.py
+++ b/corona-calculator.py
@@ -81,7 +81,7 @@ class Sidebar:
 
         st.sidebar.markdown(
             body=generate_html(
-                text=f"How many people does [...] meet on a daily basis?",
+                text=f"How many people does an individual [...] meet on a daily basis?",
                 line_height=0,
                 font_size="12px",
             )
@@ -90,9 +90,8 @@ class Sidebar:
         )
 
         slider_person_descriptions = {
-            constants.SymptomState.ASYMPTOMATIC_UNDIAGNOSED : "an individual with no symptoms",
-            constants.SymptomState.SYMPTOMATIC_UNDIAGNOSED : "an individual with unconfirmed symptoms",
-            constants.SymptomState.DIAGNOSED : "an individual diagnosed with COVID-19"
+            constants.SymptomState.ASYMPTOMATIC : "without symptoms",
+            constants.SymptomState.SYMPTOMATIC : "with symptoms",
         }
 
         self.contact_rate = {

--- a/corona-calculator.py
+++ b/corona-calculator.py
@@ -213,7 +213,7 @@ def run_app():
 
     contact_rate = sidebar.contact_rate
 
-    sir_model_2 = models.SIRModel2(
+    sir_model_2 = models.AsymptomaticSIRModel(
         transmission_rate_per_contact=constants.TransmissionRatePerContact.default_per_symptom_state,
         contact_rate=contact_rate,
         asymptomatic_cases_model=asymptomatic_cases_estimator,

--- a/corona-calculator.py
+++ b/corona-calculator.py
@@ -95,7 +95,7 @@ class Sidebar:
             constants.InfectionState.DIAGNOSED : "an individual diagnosed with COVID-19"
         }
 
-        self.contact_rates = {
+        self.contact_rate = {
             state : st.sidebar.slider(
                 label=description,
                 min_value=constants.AverageDailyContacts.min,
@@ -189,11 +189,11 @@ def run_app():
         constants.AsymptomaticRate.default
     )
 
-    contact_rates = sidebar.contact_rates
+    contact_rate = sidebar.contact_rate
 
     sir_model_2 = models.SIRModel2(
         transmission_rate_per_contact=constants.TransmissionRatePerContact.default,
-        contact_rates=contact_rates,
+        contact_rate=contact_rate,
         diagnosed_cases_model=diagnosed_cases_estimator,
         asymptomatic_cases_model=asymptomatic_cases_estimator,
         recovery_rate=constants.RecoveryRate.default,

--- a/corona-calculator.py
+++ b/corona-calculator.py
@@ -192,7 +192,7 @@ def run_app():
     contact_rate = sidebar.contact_rate
 
     sir_model_2 = models.SIRModel2(
-        transmission_rate_per_contact=constants.TransmissionRatePerContact.default,
+        transmission_rate_per_contact=constants.TransmissionRatePerContact.default_per_infection_state,
         contact_rate=contact_rate,
         diagnosed_cases_model=diagnosed_cases_estimator,
         asymptomatic_cases_model=asymptomatic_cases_estimator,

--- a/data/constants.py
+++ b/data/constants.py
@@ -28,6 +28,12 @@ class AgeData:
     data = AGE_DATA
 
 
+class InfectionState(Enum):
+    ASYMPTOMATIC_UNDIAGNOSED = "asymptomatic_undiagnosed"
+    SYMPTOMATIC_UNDIAGNOSED = "symptomatic_undiagnosed"
+    DIAGNOSED = "diagnosed"
+
+
 """
 SIR model constants
 """
@@ -55,6 +61,15 @@ class TransmissionRatePerContact:
     # Probability of a contact between carrier and susceptible leading to infection.
     # Found using binomial distribution in Wuhan scenario: 14 contacts per day, 10 infectious days, 2.5 average people infected.
     default = 0.018
+    
+    # The transmission rate of a asymptomatic infected individual is lower by a certain ratio
+    # The ratio is reported to be 55%
+    # source: https://science.sciencemag.org/content/early/2020/03/13/science.abb3221
+    default_per_infection_state = {
+        InfectionState.ASYMPTOMATIC_UNDIAGNOSED : 0.55 * default,
+        InfectionState.SYMPTOMATIC_UNDIAGNOSED : default,
+        InfectionState.DIAGNOSED : default
+    }
 
 
 class AverageDailyContacts:
@@ -83,8 +98,3 @@ class HospitalizationRate:
     # Cases requiring hospitalization. We multiply by the ascertainment rate because our source got their estimate
     # from the reported cases, whereas we will be using it with total cases.
     default = 0.19 * ReportingRate.default
-
-class InfectionState(Enum):
-    ASYMPTOMATIC_UNDIAGNOSED = "asymptomatic_undiagnosed"
-    SYMPTOMATIC_UNDIAGNOSED = "symptomatic_undiagnosed"
-    DIAGNOSED = "diagnosed"

--- a/data/constants.py
+++ b/data/constants.py
@@ -86,6 +86,5 @@ class HospitalizationRate:
 
 class InfectionState(Enum):
     ASYMPTOMATIC_UNDIAGNOSED = "asymptomatic_undiagnosed"
-    ASYMPTOMATIC_DIAGNOSED = "asymptomatic_diagnosed"
     SYMPTOMATIC_UNDIAGNOSED = "symptomatic_undiagnosed"
-    SYMPTOMATIC_DIAGNOSED = "symptomatic_diagnosed"
+    DIAGNOSED = "diagnosed"

--- a/data/constants.py
+++ b/data/constants.py
@@ -3,6 +3,7 @@ Range estimates for various epidemiology constants. Currently only default value
 For sources, please visit https://www.notion.so/Modelling-d650e1351bf34ceeb97c82bd24ae04cc
 """
 
+from enum import Enum
 import datetime
 
 from data.utils import AGE_DATA, build_country_data
@@ -71,8 +72,20 @@ class ReportingRate:
     # Proportion of true cases diagnosed
     default = 0.14
 
+class AsymptomaticRate:
+    # Proportion of true cases showing no symptoms
+    # The number comes from a study led on passengers of the Diamond Princess Cruise, in Japan
+    # We assume this figure stands true for the rest of the world
+    # https://www.eurosurveillance.org/content/10.2807/1560-7917.ES.2020.25.10.2000180
+    default = 17.9
 
 class HospitalizationRate:
     # Cases requiring hospitalization. We multiply by the ascertainment rate because our source got their estimate
     # from the reported cases, whereas we will be using it with total cases.
     default = 0.19 * ReportingRate.default
+
+class InfectionState(Enum):
+    ASYMPTOMATIC_UNDIAGNOSED = "asymptomatic_undiagnosed"
+    ASYMPTOMATIC_DIAGNOSED = "asymptomatic_diagnosed"
+    SYMPTOMATIC_UNDIAGNOSED = "symptomatic_undiagnosed"
+    SYMPTOMATIC_DIAGNOSED = "symptomatic_diagnosed"

--- a/data/constants.py
+++ b/data/constants.py
@@ -28,7 +28,7 @@ class AgeData:
     data = AGE_DATA
 
 
-class InfectionState(Enum):
+class SymptomState(Enum):
     ASYMPTOMATIC_UNDIAGNOSED = "asymptomatic_undiagnosed"
     SYMPTOMATIC_UNDIAGNOSED = "symptomatic_undiagnosed"
     DIAGNOSED = "diagnosed"
@@ -65,10 +65,10 @@ class TransmissionRatePerContact:
     # The transmission rate of a asymptomatic infected individual is lower by a certain ratio
     # The ratio is reported to be 55%
     # source: https://science.sciencemag.org/content/early/2020/03/13/science.abb3221
-    default_per_infection_state = {
-        InfectionState.ASYMPTOMATIC_UNDIAGNOSED : 0.55 * default,
-        InfectionState.SYMPTOMATIC_UNDIAGNOSED : default,
-        InfectionState.DIAGNOSED : default
+    default_per_symptom_state = {
+        SymptomState.ASYMPTOMATIC_UNDIAGNOSED : 0.55 * default,
+        SymptomState.SYMPTOMATIC_UNDIAGNOSED : default,
+        SymptomState.DIAGNOSED : default
     }
 
 

--- a/data/constants.py
+++ b/data/constants.py
@@ -77,7 +77,7 @@ class AsymptomaticRate:
     # The number comes from a study led on passengers of the Diamond Princess Cruise, in Japan
     # We assume this figure stands true for the rest of the world
     # https://www.eurosurveillance.org/content/10.2807/1560-7917.ES.2020.25.10.2000180
-    default = 17.9
+    default = 0.179
 
 class HospitalizationRate:
     # Cases requiring hospitalization. We multiply by the ascertainment rate because our source got their estimate

--- a/data/constants.py
+++ b/data/constants.py
@@ -29,9 +29,8 @@ class AgeData:
 
 
 class SymptomState(Enum):
-    ASYMPTOMATIC_UNDIAGNOSED = "asymptomatic_undiagnosed"
-    SYMPTOMATIC_UNDIAGNOSED = "symptomatic_undiagnosed"
-    DIAGNOSED = "diagnosed"
+    ASYMPTOMATIC = "asymptomatic"
+    SYMPTOMATIC = "symptomatic"
 
 
 """
@@ -66,9 +65,8 @@ class TransmissionRatePerContact:
     # The ratio is reported to be 55%
     # source: https://science.sciencemag.org/content/early/2020/03/13/science.abb3221
     default_per_symptom_state = {
-        SymptomState.ASYMPTOMATIC_UNDIAGNOSED : 0.55 * default,
-        SymptomState.SYMPTOMATIC_UNDIAGNOSED : default,
-        SymptomState.DIAGNOSED : default
+        SymptomState.ASYMPTOMATIC : 0.55 * default,
+        SymptomState.SYMPTOMATIC : default,
     }
 
 

--- a/models.py
+++ b/models.py
@@ -124,9 +124,8 @@ class AsymptomaticCasesModel:
     """
     Used to estimate total number of true infected persons in 3 categories:
     - `'asymptomatic_undiagnosed'`
-    - `'asymptomatic_diagnosed'` 
     - `'symptomatic_undiagnosed'`
-    - `'symptomatic_diagnosed'`
+    - `'diagnosed'`
 
     Uses number of diagnosed cases and true cases as input.
     """
@@ -147,9 +146,8 @@ class AsymptomaticCasesModel:
         
         ret = {
             InfectionState.ASYMPTOMATIC_UNDIAGNOSED : undiagnosed_cases * self._asymptomatic_rate,
-            InfectionState.ASYMPTOMATIC_DIAGNOSED : 0,
             InfectionState.SYMPTOMATIC_UNDIAGNOSED : undiagnosed_cases * (1 - self._asymptomatic_rate),
-            InfectionState.SYMPTOMATIC_DIAGNOSED : diagnosed_cases
+            InfectionState.DIAGNOSED : diagnosed_cases
         }
 
         return ret

--- a/models.py
+++ b/models.py
@@ -190,10 +190,8 @@ class SIRModel:
         self._hospital_capacity = hospital_capacity
 
     def _init_infection_rate(self, transmission_rate_per_contact, contact_rate):
-        
         self._infection_rate = transmission_rate_per_contact * contact_rate
         
-        return None
 
     def _get_delta_s(self, S, I, N):
         """
@@ -202,9 +200,7 @@ class SIRModel:
         :param N: Total population. 
         """
 
-        ret = - self._infection_rate * I * S / N
-        
-        return ret
+        return - self._infection_rate * I * S / N
         
     def predict(self, susceptible, infected, recovered, dead, num_days):
         """

--- a/models.py
+++ b/models.py
@@ -141,15 +141,16 @@ class AsymptomaticCasesModel:
     def predict(self, diagnosed_cases, true_cases):
         """
         Assumes the number of diagnosed asymptomatic cases is zero.
+        Equivalent to: assumes all diagnosed cases are symptomatic
         :param diagnosed_cases: Reported number of cases
         :param true_cases: Estimated number of true cases
         """
         undiagnosed_cases = true_cases - diagnosed_cases
-        
+        asymptomatic_cases = undiagnosed_cases * self._asymptomatic_rate
+
         ret = {
-            SymptomState.ASYMPTOMATIC_UNDIAGNOSED : undiagnosed_cases * self._asymptomatic_rate,
-            SymptomState.SYMPTOMATIC_UNDIAGNOSED : undiagnosed_cases * (1 - self._asymptomatic_rate),
-            SymptomState.DIAGNOSED : diagnosed_cases
+            SymptomState.ASYMPTOMATIC : asymptomatic_cases,
+            SymptomState.SYMPTOMATIC : true_cases - asymptomatic_cases
         }
 
         return ret

--- a/models.py
+++ b/models.py
@@ -186,10 +186,10 @@ class SIRModel:
     def predict(self, susceptible, infected, recovered, dead, num_days):
         """
         Run simulation.
-        :param susceptible: Number of susceptible people in population.
-        :param infected: Number of infected people in population.
-        :param recovered: Number of recovered people in population.
-        :param dead: Number of dead people in the population
+        :param susceptible: Starting number of susceptible people in population.
+        :param infected: Starting number of infected people in population.
+        :param recovered: Starting number of recovered people in population.
+        :param dead: Starting number of dead people in the population
         :param num_days: Number of days to forecast.
         :return: List of values for S, I, R over time steps
         """

--- a/models.py
+++ b/models.py
@@ -5,7 +5,7 @@ from typing import Union
 import pandas as pd
 
 import data.constants as constants
-from data.constants import InfectionState
+from data.constants import SymptomState
 
 _STATUSES_TO_SHOW = [
     "Infected",
@@ -147,9 +147,9 @@ class AsymptomaticCasesModel:
         undiagnosed_cases = true_cases - diagnosed_cases
         
         ret = {
-            InfectionState.ASYMPTOMATIC_UNDIAGNOSED : undiagnosed_cases * self._asymptomatic_rate,
-            InfectionState.SYMPTOMATIC_UNDIAGNOSED : undiagnosed_cases * (1 - self._asymptomatic_rate),
-            InfectionState.DIAGNOSED : diagnosed_cases
+            SymptomState.ASYMPTOMATIC_UNDIAGNOSED : undiagnosed_cases * self._asymptomatic_rate,
+            SymptomState.SYMPTOMATIC_UNDIAGNOSED : undiagnosed_cases * (1 - self._asymptomatic_rate),
+            SymptomState.DIAGNOSED : diagnosed_cases
         }
 
         return ret
@@ -288,9 +288,9 @@ class SIRModel2(SIRModel):
     ):
         """
         :param transmission_rate_per_contact: Prob of contact between infected and susceptible leading to infection,
-            per InfectionState
+            per SymptomState
         :param contact_rate: Mean number of daily contacts between an individual and susceptible people,
-            per InfectionState
+            per SymptomState
         :param recovery_rate: Rate of recovery of infected individuals.
         :param normal_death_rate: Average death rate in normal conditions.
         :param critical_death_rate: Rate of mortality among severe or critical cases that can't get access
@@ -319,38 +319,38 @@ class SIRModel2(SIRModel):
         contact_rate: Union[numbers.Number, dict],
     ):
         """
-        Sets self._infection_rate as a dict {InfectionState : infection_rate}
-        :param transmission_rate_per_contact: as a number or dict {InfectionState : transmission_rate_per_contact}
-        :param contact_rate: as a number or dict {InfectionState : contact_rate} 
+        Sets self._infection_rate as a dict {SymptomState : infection_rate}
+        :param transmission_rate_per_contact: as a number or dict {SymptomState : transmission_rate_per_contact}
+        :param contact_rate: as a number or dict {SymptomState : contact_rate} 
         """
         
         if isinstance(transmission_rate_per_contact, numbers.Number):
             mean_transmission_rate_per_contact = transmission_rate_per_contact 
             transmission_rate_per_contact = {
-                infection_state : mean_transmission_rate_per_contact
-                for infection_state in InfectionState
+                symptom_state : mean_transmission_rate_per_contact
+                for symptom_state in SymptomState
             }
         elif isinstance(transmission_rate_per_contact, dict): 
-            if any([infection_state not in transmission_rate_per_contact for infection_state in InfectionState]):
-                raise KeyError("tranmission_rate_per_contact must contains keys: {}".format(list(InfectionState)))
+            if any([symptom_state not in transmission_rate_per_contact for symptom_state in SymptomState]):
+                raise KeyError("tranmission_rate_per_contact must contains keys: {}".format(list(SymptomState)))
         else:
             raise TypeError("Type of tranmission_rate_per_contact must be in {}".format(Union[numbers.Number, dict]))
 
         if isinstance(contact_rate, numbers.Number):
             mean_contact_rate = contact_rate 
             contact_rate = {
-                infection_state : mean_contact_rate
-                for infection_state in InfectionState
+                symptom_state : mean_contact_rate
+                for symptom_state in SymptomState
             }
         elif isinstance(contact_rate, dict): 
-            if any([infection_state not in contact_rate for infection_state in InfectionState]):
-                raise KeyError("contact_rate must contains keys: {}".format(list(InfectionState)))
+            if any([symptom_state not in contact_rate for symptom_state in SymptomState]):
+                raise KeyError("contact_rate must contains keys: {}".format(list(SymptomState)))
         else:
             raise TypeError("Type of contact_rate must be in {}".format(Union[numbers.Number, dict]))
 
         infection_rate = {
-            infection_state : transmission_rate_per_contact[infection_state] * contact_rate[infection_state]
-            for infection_state in InfectionState
+            symptom_state : transmission_rate_per_contact[symptom_state] * contact_rate[symptom_state]
+            for symptom_state in SymptomState
         }
 
         self._infection_rate = infection_rate
@@ -368,8 +368,8 @@ class SIRModel2(SIRModel):
 
         ret = sum(
             [
-                - self._infection_rate[infection_state] * infections_per_state[infection_state] * S / N \
-                    for infection_state in InfectionState
+                - self._infection_rate[symptom_state] * infections_per_state[symptom_state] * S / N \
+                    for symptom_state in SymptomState
             ]
         ) 
         

--- a/models.py
+++ b/models.py
@@ -341,9 +341,6 @@ class SIRModel2:
                 ]
             )
 
-            print(self._infection_rate)
-            print(delta_s_t, - list(self._infection_rate.values())[0] * I[-1] * S[-1] / population)
-
             s_t = S[-1] + delta_s_t
             i_t = (
                 I[-1]

--- a/models.py
+++ b/models.py
@@ -277,7 +277,7 @@ class SIRModel:
             "Need Hospitalization": H[:-index_to_clip],
         }
 
-class SIRModel2(SIRModel):
+class AsymptomaticSIRModel(SIRModel):
     def __init__(
         self,
         transmission_rate_per_contact: Union[numbers.Number, dict],


### PR DESCRIPTION
The current sidebar allows to choose the social exposure of **an infected person**.

However, someone who uses the tool is likely not to relate to this parameter, since he/she may not feel like an infected person.

The reasons for this feeling could be:
- the user has no symptoms
- the user never underwent a test

Thus, the current control may not be seen as reflective of the user's social behaviour.

--

In this PR, I suggest to make the controls more relatable by introducing 3 sliders instead of one:

<img width="319" alt="Screenshot 2020-03-22 at 7 09 28 PM" src="https://user-images.githubusercontent.com/24707558/77248633-ebb98980-6c75-11ea-8de6-a53747081548.png">

This stresses that even a asymptomatic person can carry the virus and spread it to others.

The asymptomatic ratio is taken from this [paper](https://www.eurosurveillance.org/content/10.2807/1560-7917.ES.2020.25.10.2000180), which studied the population of the Diamond Princess cruise, which was subject to more extensive testing.

The epidemiological model is still an SIR, with different `infection_rate` for the 3 three populations (which depend on their average number of social interactions).


